### PR TITLE
Fix Machine config handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # E2C-Revamp
+
+This repository contains a small Flask backend and React frontend for experimenting with workload scheduling algorithms.
+
+## Configuration JSON
+
+The backend exposes `/api/workload/upload/config` which accepts a JSON file describing the available machines. Each machine object requires a `type` string and may include `speed` and `id` fields.
+
+Example file:
+
+```json
+{
+  "machines": [
+    { "id": "M1", "type": "basic", "speed": 1 },
+    { "id": "M2", "type": "advanced", "speed": 2 }
+  ]
+}
+```
+
+Upload this file using `multipart/form-data` with the key `file`. A successful request responds with `{"message": "Configuration loaded"}`.
+
+For convenience the `server/scripts/test_upload_config.py` script demonstrates how to
+send such a request using the [requests](https://pypi.org/project/requests/) library.

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,3 +1,4 @@
 Flask==2.3.3
 Flask-Cors==4.0.0
 python-dotenv==1.0.1
+requests==2.31.0

--- a/server/routes/workload.py
+++ b/server/routes/workload.py
@@ -60,9 +60,10 @@ def upload_config():
         # Construct machine list from config
         machine_list = []
         for m in config_data.get("machines", []):
-            machine_type = MachineType[m["type"]]
-            speed = m["speed"]
-            machine = Machine(machine_type, speed)
+            machine_type = MachineType(m["type"])
+            speed = m.get("speed", 1)
+            identifier = m.get("id")
+            machine = Machine(machine_type, speed=speed, identifier=identifier)
             machine_list.append(machine)
 
         config.machines = machine_list

--- a/server/scripts/test_upload_config.py
+++ b/server/scripts/test_upload_config.py
@@ -1,0 +1,22 @@
+import json
+import requests
+
+URL = "http://localhost:5001/api/workload/upload/config"
+
+def main():
+    sample = {
+        "machines": [
+            {"id": "M1", "type": "basic", "speed": 1}
+        ]
+    }
+    with open("temp_config.json", "w") as f:
+        json.dump(sample, f)
+
+    with open("temp_config.json", "rb") as f:
+        response = requests.post(URL, files={"file": f})
+
+    print("Status:", response.status_code)
+    print("Response:", response.json())
+
+if __name__ == "__main__":
+    main()

--- a/server/utils/config_loader.py
+++ b/server/utils/config_loader.py
@@ -1,6 +1,6 @@
 import json
 import server.utils.config as config
-from server.utils.machine import Machine  # Update path if needed
+from server.utils.machine import Machine, MachineType
 
 def load_config_file(path):
     with open(path, 'r') as f:
@@ -9,8 +9,10 @@ def load_config_file(path):
     machines = []
     for m in data.get("machines", []):
         type_name = m.get("type")
-        cores = m.get("cores", 1)
-        machines.append(Machine(type_name=type_name, cores=cores))
+        speed = m.get("speed", 1)
+        identifier = m.get("id")
+        machine_type = MachineType(type_name)
+        machines.append(Machine(machine_type, speed=speed, identifier=identifier))
 
     config.machines = machines
     config.no_of_machines = len(machines)

--- a/server/utils/machine.py
+++ b/server/utils/machine.py
@@ -6,8 +6,24 @@ class MachineType:
 
 
 class Machine:
-    def __init__(self, machine_type, queue_limit=5):
-        self.type = machine_type  # instance of MachineType
+    def __init__(self, machine_type, speed=1, identifier=None, queue_limit=5):
+        """Represents a machine in the simulator.
+
+        Parameters
+        ----------
+        machine_type : MachineType
+            The type of machine this instance represents.
+        speed : int, optional
+            Processing speed of the machine. Defaults to ``1``.
+        identifier : str | int, optional
+            Optional unique identifier for the machine.
+        queue_limit : int, optional
+            Maximum number of tasks that can wait in the queue.
+        """
+
+        self.type = machine_type
+        self.speed = speed
+        self.id = identifier
         self.queue = Queue(maxsize=queue_limit)
         self.running_task = None
 
@@ -37,4 +53,5 @@ class Machine:
     def __repr__(self):
         running_id = self.running_task[0].id if self.running_task else "None"
         queued_ids = [task.id for task in list(self.queue.queue)]
-        return f"<Machine {self.type.name}, Running: {running_id}, Queue: {queued_ids}>"
+        label = self.id if self.id is not None else self.type.name
+        return f"<Machine {label} speed={self.speed}, Running: {running_id}, Queue: {queued_ids}>"


### PR DESCRIPTION
## Summary
- fix machine parsing when uploading configuration JSON
- store speed and identifier on `Machine` objects
- adjust config loader to build machines correctly
- document config file format in `README`
- add helper script to test config uploads
- include `requests` in server requirements

## Testing
- `python -m py_compile server/utils/machine.py server/utils/config_loader.py server/routes/workload.py server/scripts/test_upload_config.py`

------
https://chatgpt.com/codex/tasks/task_e_6849b1705d048324943b83cc0b9bce0d