### PR TITLE
Enable FCFS simulation via uploaded workload

### DIFF
--- a/client/src/SimDashboard.jsx
+++ b/client/src/SimDashboard.jsx
@@ -153,14 +153,23 @@ const SimDashboard = () => {
     }
   };
 
-  const handleSubmitWorkloadAndProfiling = () => {
+  const handleSubmitWorkloadAndProfiling = async () => {
     if (!workloadFileUploaded || !profilingFileUploaded) {
       alert("Please upload both the workload (.wkl) and profiling table (.eet) files before submitting.");
       return;
     }
 
-    alert("Workload and Profiling Table submitted successfully!");
-    // Add any additional logic for submission here
+    try {
+      const res = await axios.post(
+        "http://localhost:5001/api/workload/simulate/fcfs",
+        { tasks: workloadTableData }
+      );
+      setFcfsResults(res.data.results);
+      alert("Workload and Profiling Table submitted successfully!");
+    } catch (err) {
+      console.error("Simulation error:", err);
+      alert("Failed to run simulation.");
+    }
   };
 
   const handleResetWorkload = () => {


### PR DESCRIPTION
## Summary
- call backend route `/api/workload/simulate/fcfs` from the workload submit
- show results in existing FCFS table

## Testing
- `npm test` *(fails: Missing script)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6849cf9751088324ae37f6633454b025