### PR TITLE
Enable FCFS simulation via play button

### DIFF
--- a/client/src/SimDashboard.jsx
+++ b/client/src/SimDashboard.jsx
@@ -173,12 +173,17 @@ const SimDashboard = () => {
   };
 
   const runFCFSSimulation = async () => {
+    if (workloadTableData.length === 0) {
+      alert("Please upload a workload file before running the simulation.");
+      return;
+    }
+
     try {
-      const response = await axios.post("http://localhost:5001/api/scheduling/fcfs", {
-        numTasks: 6,
-        configFilename: configFileName
-      });
-      setFcfsResults(response.data);
+      const response = await axios.post(
+        "http://localhost:5001/api/workload/simulate/fcfs",
+        { tasks: workloadTableData }
+      );
+      setFcfsResults(response.data.results);
       alert("Simulation complete!");
     } catch (error) {
       console.error("Error running simulation:", error);


### PR DESCRIPTION
## Summary
- only store workload and profiling when submitted
- trigger `/api/workload/simulate/fcfs` from the play button
- show results in existing FCFS table

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6849cf9751088324ae37f6633454b025